### PR TITLE
(v2.6)Ansible実行エージェント_ユーザーセッション切断後のプロセス維持設定追加

### DIFF
--- a/src/ja/2.6/configuration/ansible/ansible_execution_agent.rst
+++ b/src/ja/2.6/configuration/ansible/ansible_execution_agent.rst
@@ -245,3 +245,15 @@ Ansible builderで使用する動作確認済みのベースイメージ
      - registry.redhat.io/ansible-automation-platform-24/ee-supported-rhel9:latest
      - サポート付きライセンス利用の場合
 
+.. _ansible-agent-linger-note:
+
+ユーザーセッション切断後のプロセス維持
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+| Ansible実行エージェントを構成したエージェントユーザーがログアウトするとプロセスが停止し、ITAの作業実行がタイムアウトします。
+
+| 以下のコマンドを実行し、エージェントユーザーのプロセスがログアウト後も継続して動作するよう設定してください。
+| ※ `<agent_user>` には、使用しているAnsible実行ユーザー名を指定してください。
+
+.. code-block:: bash
+
+   loginctl enable-linger <agent_user>


### PR DESCRIPTION
【v2.6】Ansible実行エージェントの構成・構築ガイドに、ユーザーセッション切断後のプロセス維持設定方法を追加